### PR TITLE
fix(autoupdate): autoupdater will install updates when quitting the app

### DIFF
--- a/src/client/boot/Websocket.tsx
+++ b/src/client/boot/Websocket.tsx
@@ -85,6 +85,14 @@ export class WebsocketContainer extends React.Component<
                 case 'REPORT_ISSUE':
                     Sentry.showReportDialog();
                     break;
+
+                case 'MESSAGE':
+                    dispatch(
+                        actions.notifications.notify(
+                            action.payload.message,
+                            action.payload.type
+                        )
+                    );
             }
         });
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,7 +107,7 @@ app.on('activate', () => {
 
 // create main BrowserWindow when electron is ready
 app.on('ready', async () => {
-    update();
+    update(app);
 
     log.info('app is ready');
 


### PR DESCRIPTION
The autoupdater will no longer terminate the app to install updates. Instead it will wait for the user to quit the application and then update the app.