### PR TITLE
fix(links): open external links in default browser (fixes #50)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -87,6 +87,11 @@ function createMainWindow(): electron.BrowserWindow {
         });
     });
 
+    window.webContents.on('will-navigate', (e, url) => {
+        e.preventDefault();
+        require('electron').shell.openExternal(url);
+    });
+
     return window;
 }
 


### PR DESCRIPTION
Hey,

electron now opens external links in a new browser window. This prevents the issues described in #50.