### PR TITLE
fix(ui): removed superfluous horizontal scroll bar

### DIFF
--- a/src/client/views/Editor/H5P/index.tsx
+++ b/src/client/views/Editor/H5P/index.tsx
@@ -105,24 +105,20 @@ export class H5PContainer extends React.Component<IProps, IComponentState> {
                     <ModeTab mode={mode} changeMode={this.changeMode} />
                 ) : null}
                 <div>
-                    <Grid container={true} spacing={2}>
-                        <Grid item={true} xs={10}>
-                            <ErrorBoundary>
-                                <ContentPaper>
-                                    <H5P
-                                        key={activeTab.contentId}
-                                        contentId={activeTab.contentId}
-                                        tabId={activeTab.id}
-                                        mode={mode}
-                                        update={(
-                                            params: any,
-                                            library: string
-                                        ) => this.update()}
-                                    />
-                                </ContentPaper>
-                            </ErrorBoundary>
-                        </Grid>
-                        <Grid item={true} xs={2} />
+                    <Grid style={{ marginRight: '72px' }}>
+                        <ErrorBoundary>
+                            <ContentPaper>
+                                <H5P
+                                    key={activeTab.contentId}
+                                    contentId={activeTab.contentId}
+                                    tabId={activeTab.id}
+                                    mode={mode}
+                                    update={(params: any, library: string) =>
+                                        this.update()
+                                    }
+                                />
+                            </ContentPaper>
+                        </ErrorBoundary>
                     </Grid>
                 </div>
                 {activeTab.state !== 'opening' ? (


### PR DESCRIPTION
I've changed the grid structure to remove the unneccesary horizontal scroll bar in the editor. The margin to the right is now also as wide as the button an not 2 columns.

**Before:**
![2020-04-12 10_05_28-Lumi](https://user-images.githubusercontent.com/15268740/79063992-7d308000-7ca5-11ea-96bc-8990f5e46903.png)

**Now:**
![2020-04-12 10_04_56-Lumi](https://user-images.githubusercontent.com/15268740/79063994-802b7080-7ca5-11ea-82e8-f8e53ecec61d.png)