### PR TITLE
docs(husky): husky now uses npm install instead of npm ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
             "pre-commit": "npm run lint && npm run format:check",
             "pre-push": "npm run ci",
             "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-            "post-merge": "npm ci && npm run ci",
-            "post-checkout": "npm ci"
+            "post-merge": "rm -rf node_modules && npm install && npm run ci",
+            "post-checkout": "rm -rf node_modules && npm install"
         }
     },
     "browserslist": {


### PR DESCRIPTION
The npm ci command didn't work on Windows, so the node_modules directory is now deleted manually and the regular npm install is run.