### PR TITLE
fix(editor): file uploads are now displayed in the editor

### DIFF
--- a/src/client/public/index.html
+++ b/src/client/public/index.html
@@ -156,7 +156,7 @@
                         '/api/v1/h5p/editor/ckeditor/ckeditor.js'
                     ]
                 },
-                filesPath: '/api/v1/h5p/content',
+                filesPath: '/api/v1/h5p/tmp',
                 fileIcon: {
                     path:
                         'http://lumi.education/api/h5p/v1/editor/images/binary-file.png',

--- a/src/client/views/Editor/H5P/H5P.tsx
+++ b/src/client/views/Editor/H5P/H5P.tsx
@@ -62,8 +62,6 @@ export default class Editor extends React.Component<IProps, IComponentState> {
                 // Required styles and scripts for the editor
                 H5PEditor.assets = H5PIntegration.editor.assets;
 
-                H5PEditor.filesPath = `${h5pConfig.baseUrl}${h5pConfig.contentFilesUrl}${self.props.contentId}`;
-
                 // Required for assets
                 H5PEditor.baseUrl = h5pConfig.baseUrl;
 


### PR DESCRIPTION
There was a bug that made the H5P editor client generate incorrect paths to temporary files. Closes #661 .