### PR TITLE
ci(release): release only from release-branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
     push:
         branches:
-            - master
+            - release
 
 jobs:
     release:

--- a/release.config.js
+++ b/release.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+    branches: ['release'],
     plugins: [
         '@semantic-release/commit-analyzer',
         '@semantic-release/release-notes-generator',


### PR DESCRIPTION
Hey,

in order to reduce the release-frequency and add the ability to test the app manually before releasing I configured the semantic-release-module and the github actions to only release from the `release`-branch.