### PR TITLE
ci(build): pacman and deb packages for linux

### DIFF
--- a/builder.config.js
+++ b/builder.config.js
@@ -36,7 +36,7 @@ module.exports = {
     },
     linux: {
         category: 'Utility',
-        target: ['AppImage', 'snap']
+        target: ['AppImage', 'snap', 'deb', 'pacman']
     },
     dmg: {
         sign: false

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "lumi",
     "version": "0.3.1",
     "description": "A tool to create and display interactive content with H5P",
-    "author": "J.P. Schellenberg",
+    "author": "J.P. Schellenberg <c@Lumi.education>",
     "main": "build/main.js",
     "dependencies": {
         "@sentry/electron": "2.0.4",
@@ -26,6 +26,8 @@
         "build:all": "npm run build && ./node_modules/.bin/electron-builder --config builder.config.js --mac --win --linux --publish never",
         "build:all:dev": "CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:all",
         "build:client": "node scripts/build.js",
+        "build:linux": "npm run build && ./node_modules/.bin/electron-builder --config builder.config.js --linux --publish never",
+        "build:linux:dev": "CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:linux",
         "build:mac": "npm run build && ./node_modules/.bin/electron-builder --config builder.config.js --mac --publish never",
         "build:mac:dev": "CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:mac",
         "build:sentry": "RELEASE=true npm run build:client",


### PR DESCRIPTION
I just needed this because snap doesn't work out of the box in archlinux.

I've tested the deb file on ubuntu 20
04 and pacman package on archlinux they both work.