### PR TITLE
feat(server): in-memory cache speeds up editor load times

### DIFF
--- a/server/src/boot/createH5PEditor.ts
+++ b/server/src/boot/createH5PEditor.ts
@@ -27,7 +27,9 @@ export default async function createH5PEditor(
     const h5pEditor = new H5P.H5PEditor(
         new H5P.fsImplementations.InMemoryStorage(), // this is a general-purpose cache
         config,
-        new H5P.fsImplementations.FileLibraryStorage(localLibraryPath),
+        new H5P.cacheImplementations.CachedLibraryStorage(
+            new H5P.fsImplementations.FileLibraryStorage(localLibraryPath)
+        ),
         new H5P.fsImplementations.FileContentStorage(localContentPath),
         new H5P.fsImplementations.DirectoryTemporaryFileStorage(
             localTemporaryPath


### PR DESCRIPTION
Closes #1123 .
The editor loads much faster after some content types have been used. The first loads are not improved as the cache has to be rebuilt every time the app starts.

It's important that the library storage is not manipulated anywhere outside of the library storage used by H5P Editor, as this will lead to invalid cache states! This is currently not the case, but we must bear this in mind in the future.