### PR TITLE
test(jest): update jest config to exculde test-folder for unit-tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -103,7 +103,7 @@ module.exports = {
     // rootDir: null,
 
     // A list of paths to directories that Jest should use to search for files in
-    roots: ['<rootDir>'],
+    roots: ['<rootDir>/client', '<rootDir>/server'],
 
     // Allows you to use a custom runner instead of Jest's default test runner
     // runner: "jest-runner",
@@ -133,7 +133,7 @@ module.exports = {
     // ],
 
     // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-    testPathIgnorePatterns: ['/node_modules/', 'test/mac', 'test/win'],
+    testPathIgnorePatterns: ['/node_modules/', '<rootDir>/test'],
 
     // The regexp pattern or array of patterns that Jest uses to detect test files
     // testRegex: [],


### PR DESCRIPTION
Hey,

I excluded the `test/` folder from the normal `npm run test`-command as the unit-tests are found in various __test__ folder throughout `server/` and `client/`. The tests in `test/` are expensive e2e-tests used by the CI that should not be run on every file change.