### PR TITLE
ci(release-linux): install libarchive-tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,8 @@ jobs:
               run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
               env:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+            - name: install labarchive-tools
+              run: sudo apt install libarchive-tools
             - name: install
               run: npm ci && (cd client && npm ci)
             - name: Build


### PR DESCRIPTION
Hey,

as the libarchive-tools is needed in the build-pipeline I guess it will be needed when building the release.