### PR TITLE
fix(player): content resizes with window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7824,6 +7824,12 @@
             "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
             "dev": true
         },
+        "prettier": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+            "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+            "dev": true
+        },
         "pretty-format": {
             "version": "26.6.2",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "electron-notarize": "1.0.0",
         "husky": "4.3.7",
         "jest": "26.6.0",
+        "prettier": "^2.2.1",
         "spectron": "13.0.0",
         "ts-jest": "26.4.4",
         "tslint": "6.1.3",

--- a/server/src/routes/h5pRoutes.ts
+++ b/server/src/routes/h5pRoutes.ts
@@ -26,7 +26,12 @@ export default function (
 
     router.get(`/:contentId/play`, async (req, res) => {
         try {
-            const content = await h5pPlayer.render(req.params.contentId);
+            const content = (await h5pPlayer.render(
+                req.params.contentId
+            )) as H5P.IPlayerModel;
+            // We override the embed types to make sure content always resizes
+            // properly.
+            content.embedTypes = ['iframe'];
             res.send(content);
             res.status(200).end();
         } catch (error) {


### PR DESCRIPTION
Changed the embed type to iframe to make re-sizing easier. This should also prevent H5P styles and scripts from leaking into Lumi, which is good.

Prettier wasn't a dev dependency of the server, so I added it.