### PR TITLE
fix big report files due to imageSlideBackground and background (fixes #1226)

### DIFF
--- a/reporter-client/src/App.tsx
+++ b/reporter-client/src/App.tsx
@@ -40,7 +40,12 @@ declare var window: {
 
 function removeFile(obj: any) {
     for (let key in obj) {
-        if (key === 'file' || key === 'files') {
+        if (
+            key === 'file' ||
+            key === 'files' ||
+            key === 'imageSlideBackground' ||
+            key === 'background'
+        ) {
             delete obj[key];
         } else if (typeof obj[key] === 'object') {
             removeFile(obj[key]);


### PR DESCRIPTION
Hey,

the reporter now also removes the imageSlideBackground and background fields of the content.json in order to reduce the reporter-filesize.