### PR TITLE
fix(export-dialog): was not closed when title was missing

### DIFF
--- a/client/src/state/H5PEditor/H5PEditorReducer.ts
+++ b/client/src/state/H5PEditor/H5PEditorReducer.ts
@@ -208,7 +208,8 @@ export default function tabReducer(
                                   loadingIndicator: false
                               }
                             : tab
-                    )
+                    ),
+                    showExportDialog: false
                 };
 
             case H5P_LOADPLAYERCONTENT_REQUEST:

--- a/client/src/state/H5PEditor/__tests__/H5PEditorReducer.test.ts
+++ b/client/src/state/H5PEditor/__tests__/H5PEditorReducer.test.ts
@@ -1,3 +1,4 @@
+import { showReportDialog } from '@sentry/browser';
 import shortid from 'shortid';
 
 import { default as reducer, initialState } from '../H5PEditorReducer';
@@ -114,7 +115,8 @@ describe('H5PEDITOR_EXPORT_ERROR', () => {
                     ...testTab,
                     loadingIndicator: true
                 }
-            ]
+            ],
+            showExportDialog: true
         },
         {
             payload: {
@@ -126,6 +128,11 @@ describe('H5PEDITOR_EXPORT_ERROR', () => {
 
     it('sets the loadingIndicator to false', (done) => {
         expect(state.tabList[0].loadingIndicator).toBeFalsy();
+        done();
+    });
+
+    it('closes the export Dialog', (done) => {
+        expect(state.showExportDialog).toBeFalsy();
         done();
     });
 });


### PR DESCRIPTION
Hey,

this PR fixes a bug where the export dialog was not closeable anymore when exporting a file without giving a title. 
Now the export dialog should also close on errors.

