### PR TITLE
refactor(tracking): get library names of the h5p saved&opened

### DIFF
--- a/client/src/state/Analytics/AnalyticsActions.ts
+++ b/client/src/state/Analytics/AnalyticsActions.ts
@@ -20,7 +20,7 @@ export function importAnalytics(): any {
         track('Analytics', 'import');
         try {
             const { users, interactions } = await API.importAnalytics();
-            track('Analytics', 'import', `${interactions.map((i) => i.name)}`);
+            track('Analytics', 'import', `content-types`, interactions.length);
 
             dispatch({
                 payload: { users, interactions },

--- a/client/src/state/Analytics/AnalyticsActions.ts
+++ b/client/src/state/Analytics/AnalyticsActions.ts
@@ -20,12 +20,7 @@ export function importAnalytics(): any {
         track('Analytics', 'import');
         try {
             const { users, interactions } = await API.importAnalytics();
-            track(
-                'Analytics',
-                'import',
-                'content-types',
-                `${interactions.map((i) => i.name)}`
-            );
+            track('Analytics', 'import', `${interactions.map((i) => i.name)}`);
 
             dispatch({
                 payload: { users, interactions },

--- a/client/src/state/H5PEditor/H5PEditorActions.ts
+++ b/client/src/state/H5PEditor/H5PEditorActions.ts
@@ -130,7 +130,11 @@ export function exportH5P(includeReporter: boolean): any {
             try {
                 await api.exportAsHtml(data.contentId, includeReporter);
 
-                track('H5P', 'export', 'tracker', `${includeReporter}`);
+                track(
+                    'H5P',
+                    'export_as_html',
+                    `${includeReporter ? 'with_reporter' : 'without_reporter'}`
+                );
                 dispatch({
                     payload: { contentId: data.contentId, includeReporter },
                     type: H5PEDITOR_EXPORT_SUCCESS
@@ -413,7 +417,7 @@ export function save(
             const response = await api.exportH5P(data.contentId, path);
 
             try {
-                track('H5P', 'save');
+                track('H5P', 'save', data.metadata?.mainLibrary);
             } catch (error) {
                 Sentry.captureException(error);
             }
@@ -457,12 +461,7 @@ export function importH5P(
             .importH5P(path)
             .then(({ body }) => {
                 try {
-                    track(
-                        'H5P',
-                        'import',
-                        'content-type',
-                        body.metadata.mainLibrary
-                    );
+                    track('H5P', 'open', body.metadata.mainLibrary);
                 } catch (error) {
                     Sentry.captureException(error);
                 }

--- a/client/src/state/H5PEditor/H5PEditorActions.ts
+++ b/client/src/state/H5PEditor/H5PEditorActions.ts
@@ -132,7 +132,7 @@ export function exportH5P(includeReporter: boolean): any {
 
                 track(
                     'H5P',
-                    'export_as_html',
+                    'export_as_single_html',
                     `${includeReporter ? 'with_reporter' : 'without_reporter'}`
                 );
                 dispatch({

--- a/client/src/state/track/actions.ts
+++ b/client/src/state/track/actions.ts
@@ -4,7 +4,7 @@ export function track(
     category: string,
     action: string,
     name?: string,
-    value?: string
+    value?: number
 ): any {
     return api.track(category, action, name, value).then(() => {
         return {

--- a/client/src/state/track/api.ts
+++ b/client/src/state/track/api.ts
@@ -4,7 +4,7 @@ export function track(
     category: string,
     action: string,
     name?: string,
-    value?: string
+    value?: number
 ): Promise<superagent.Response> {
     return superagent.post('/api/v1/track').send({
         action,


### PR DESCRIPTION
Hey,

I refactored the tracking methods to get the h5p-libraries that are used when saving/opening.