### PR TITLE
fix(menu): websocket-actions are named correct

### DIFF
--- a/server/src/menu/analyticsMenu.ts
+++ b/server/src/menu/analyticsMenu.ts
@@ -11,7 +11,7 @@ export default (window: electron.BrowserWindow, websocket: SocketIO.Server) => [
             {
                 accelerator: 'CmdOrCtrl+O',
                 click: () => {
-                    websocket.emit('lumi:action', {
+                    websocket.emit('action', {
                         payload: {},
                         type: 'IMPORT_ANALYTICS'
                     });

--- a/server/src/menu/h5peditorMenu.ts
+++ b/server/src/menu/h5peditorMenu.ts
@@ -11,7 +11,7 @@ export default (window: electron.BrowserWindow, websocket: SocketIO.Server) => [
             {
                 accelerator: 'CmdOrCtrl+N',
                 click: () => {
-                    websocket.emit('lumi:action', {
+                    websocket.emit('action', {
                         payload: {
                             contentId: Math.round(Math.random() * 100000)
                         },
@@ -35,7 +35,7 @@ export default (window: electron.BrowserWindow, websocket: SocketIO.Server) => [
                             properties: ['openFile', 'multiSelections']
                         })
                         .then(({ filePaths }) => {
-                            websocket.emit('lumi:action', {
+                            websocket.emit('action', {
                                 payload: {
                                     paths: filePaths
                                 },
@@ -49,7 +49,7 @@ export default (window: electron.BrowserWindow, websocket: SocketIO.Server) => [
             {
                 accelerator: 'CmdOrCtrl+S',
                 click: () => {
-                    websocket.emit('lumi:action', {
+                    websocket.emit('action', {
                         type: 'SAVE'
                     });
                 },
@@ -58,7 +58,7 @@ export default (window: electron.BrowserWindow, websocket: SocketIO.Server) => [
             {
                 accelerator: 'Shift+CmdOrCtrl+S',
                 click: () => {
-                    websocket.emit('lumi:action', {
+                    websocket.emit('action', {
                         type: 'SAVE_AS'
                     });
                 },
@@ -67,7 +67,7 @@ export default (window: electron.BrowserWindow, websocket: SocketIO.Server) => [
             { type: 'separator' } as any,
             {
                 click: () => {
-                    websocket.emit('lumi:action', {
+                    websocket.emit('action', {
                         type: 'EXPORT_AS_HTML'
                     });
                 },

--- a/server/src/menu/helpMenu.ts
+++ b/server/src/menu/helpMenu.ts
@@ -11,7 +11,7 @@ export default function (
         submenu: [
             {
                 click: () => {
-                    websocket.emit('lumi:action', {
+                    websocket.emit('action', {
                         type: 'REPORT_ISSUE'
                     });
                 },


### PR DESCRIPTION
Hey,

the websocket action was falsely labeled like the translation strings which prevented the menu from working. I fixed that and now the menu should work again with the keyboard accelerators.