### PR TITLE
fix(devmode): pass undefined if libs is not set

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -148,7 +148,10 @@ app.on('ready', async () => {
         mainWindow,
         {
             devMode: app.commandLine.hasSwitch('dev'),
-            libraryDir: app.commandLine.getSwitchValue('libs')
+            libraryDir:
+                app.commandLine.getSwitchValue('libs') !== ''
+                    ? app.commandLine.getSwitchValue('libs')
+                    : undefined
         }
     );
     log.info('server booted');


### PR DESCRIPTION
Hey,

I found a bug with the dev mode. If the commandline swtich value for libs is not set it will be passed as an empty string. But it should be passed as undefined, so I fixed that.