### PR TITLE
feat(prereleases): allow prereleases to test future features

### DIFF
--- a/client/src/state/Settings/SettingsReducer.ts
+++ b/client/src/state/Settings/SettingsReducer.ts
@@ -17,7 +17,8 @@ export const initialState: ISettingsState = {
     autoUpdates: false,
     language: 'en',
     email: '',
-    token: ''
+    token: '',
+    allowPrerelease: false
 };
 
 export default function settingsReducer(

--- a/client/src/state/Settings/SettingsTypes.ts
+++ b/client/src/state/Settings/SettingsTypes.ts
@@ -12,6 +12,7 @@ export interface ISettingsState {
     language: string;
     email: string;
     token: string;
+    allowPrerelease: boolean;
 }
 
 export const SETTINGS_GET_SETTINGS_REQUEST = 'SETTINGS_GET_SETTINGS_REQUEST';

--- a/client/src/views/Launchpad.tsx
+++ b/client/src/views/Launchpad.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { History } from 'history';
 
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next';
 import MainSection from './components/MainSection';
 import { Link } from 'react-router-dom';
 
+import { IState } from '../state';
 import { track } from '../state/track/actions';
 
 declare var window: {
@@ -63,6 +64,9 @@ export default function Launchpad() {
     const { t } = useTranslation();
     const dispatch = useDispatch();
     const history = useHistory();
+    const allowPrerelease = useSelector(
+        (state: IState) => state.settings.allowPrerelease
+    );
 
     window.h = history;
 
@@ -207,57 +211,61 @@ export default function Launchpad() {
                             </CardActions>
                         </Card>
                     </Grid>
-                    <Grid item xs={4}>
-                        <Card id="launchpad-run" className={classes.card}>
-                            <Link
-                                to="/run"
-                                style={{
-                                    color: 'inherit',
-                                    textDecoration: 'inherit'
-                                }}
-                            >
-                                <CardActionArea>
-                                    <CardMedia
-                                        className={classes.media}
-                                        title="Lumi Run"
-                                    >
-                                        <RunIcon
-                                            className={classes.analyticsIcon}
-                                        />
-                                    </CardMedia>
-                                    <CardContent>
-                                        <Typography
-                                            gutterBottom
-                                            variant="h5"
-                                            component="h2"
+                    {allowPrerelease && (
+                        <Grid item xs={4}>
+                            <Card id="launchpad-run" className={classes.card}>
+                                <Link
+                                    to="/run"
+                                    style={{
+                                        color: 'inherit',
+                                        textDecoration: 'inherit'
+                                    }}
+                                >
+                                    <CardActionArea>
+                                        <CardMedia
+                                            className={classes.media}
+                                            title="Lumi Run"
                                         >
-                                            Lumi Run
-                                        </Typography>
-                                        <Typography
-                                            variant="body2"
-                                            color="textSecondary"
-                                            component="p"
+                                            <RunIcon
+                                                className={
+                                                    classes.analyticsIcon
+                                                }
+                                            />
+                                        </CardMedia>
+                                        <CardContent>
+                                            <Typography
+                                                gutterBottom
+                                                variant="h5"
+                                                component="h2"
+                                            >
+                                                Lumi Run (Beta)
+                                            </Typography>
+                                            <Typography
+                                                variant="body2"
+                                                color="textSecondary"
+                                                component="p"
+                                            >
+                                                {t('run.description')}
+                                            </Typography>
+                                        </CardContent>
+                                    </CardActionArea>
+                                </Link>
+                                <CardActions>
+                                    <Button size="small" color="primary">
+                                        <Link
+                                            to="/run"
+                                            style={{
+                                                color: 'inherit',
+                                                textDecoration: 'inherit'
+                                            }}
                                         >
-                                            {t('run.description')}
-                                        </Typography>
-                                    </CardContent>
-                                </CardActionArea>
-                            </Link>
-                            <CardActions>
-                                <Button size="small" color="primary">
-                                    <Link
-                                        to="/run"
-                                        style={{
-                                            color: 'inherit',
-                                            textDecoration: 'inherit'
-                                        }}
-                                    >
-                                        {t('analytics.startPage.start')}
-                                    </Link>
-                                </Button>
-                            </CardActions>
-                        </Card>
-                    </Grid>
+                                            {t('analytics.startPage.start')}
+                                        </Link>
+                                    </Button>
+                                </CardActions>
+                            </Card>
+                        </Grid>
+                    )}
                 </Grid>
             </MainSection>
         </div>

--- a/client/src/views/components/RunSetupDialog.tsx
+++ b/client/src/views/components/RunSetupDialog.tsx
@@ -120,7 +120,7 @@ export default function RunSetupDialog(props: IRunSetupDialogProps) {
             open={open}
         >
             <DialogTitle id="customized-dialog-title" onClose={onClose}>
-                Lumi Run
+                Lumi Run (Beta)
             </DialogTitle>
             <DialogContent dividers>
                 <Typography gutterBottom>{t('run.description')}</Typography>

--- a/client/src/views/components/Settings/GeneralSettingsList.tsx
+++ b/client/src/views/components/Settings/GeneralSettingsList.tsx
@@ -15,6 +15,7 @@ import BugReportIcon from '@material-ui/icons/BugReport';
 import InsertChartIcon from '@material-ui/icons/InsertChart';
 
 import TranslateIcon from '@material-ui/icons/Translate';
+import UpdateIcon from '@material-ui/icons/Update';
 
 import { actions, IState } from '../../../state';
 import LanguageList from './LanguageList';
@@ -91,6 +92,33 @@ export default function SettingsGeneralSettingsList() {
                         checked={settings.usageStatistics}
                         inputProps={{
                             'aria-labelledby': 'switch-list-label-bluetooth'
+                        }}
+                    />
+                </ListItemSecondaryAction>
+            </ListItem>
+            <ListItem>
+                <ListItemIcon>
+                    <UpdateIcon />
+                </ListItemIcon>
+                <ListItemText
+                    id="switch-list-label-updates"
+                    primary={t('prerelease.title')}
+                    secondary={t('prerelease.description')}
+                />
+                <ListItemSecondaryAction>
+                    <Switch
+                        edge="end"
+                        onChange={() =>
+                            dispatch(
+                                actions.settings.changeSetting({
+                                    allowPrerelease: !settings.allowPrerelease
+                                })
+                            )
+                        }
+                        checked={settings.allowPrerelease}
+                        inputProps={{
+                            'aria-labelledby':
+                                'switch-list-label-prerelease-updates'
                         }}
                     />
                 </ListItemSecondaryAction>

--- a/locales/lumi/en.json
+++ b/locales/lumi/en.json
@@ -12,6 +12,10 @@
         },
         "messages": { "econnrefused": "Connection Refused" }
     },
+    "prerelease": {
+        "title": "Prerelease Features",
+        "description": "Enable experimental features before they are released"
+    },
     "auth": {
         "set_email": "Set Email",
         "email": "Email",

--- a/server/src/boot/defaultSettings.ts
+++ b/server/src/boot/defaultSettings.ts
@@ -9,5 +9,6 @@ export default {
     autoUpdates: false,
     language: 'en',
     email: '',
-    token: ''
+    token: '',
+    allowPrerelease: false
 };

--- a/server/src/settingsCache.ts
+++ b/server/src/settingsCache.ts
@@ -1,4 +1,5 @@
 interface ISettingsState {
+    allowPrerelease: boolean;
     autoUpdates: boolean;
     bugTracking: boolean;
     email: string;
@@ -8,7 +9,6 @@ interface ISettingsState {
     privacyPolicyConsent: boolean;
     token: string;
     usageStatistics: boolean;
-    allowPrerelease: boolean;
 }
 
 import defaultSettings from './boot/defaultSettings';

--- a/server/src/settingsCache.ts
+++ b/server/src/settingsCache.ts
@@ -8,6 +8,7 @@ interface ISettingsState {
     privacyPolicyConsent: boolean;
     token: string;
     usageStatistics: boolean;
+    allowPrerelease: boolean;
 }
 
 import defaultSettings from './boot/defaultSettings';

--- a/server/src/updater.ts
+++ b/server/src/updater.ts
@@ -4,6 +4,7 @@ import SocketIO from 'socket.io';
 import * as Sentry from '@sentry/electron';
 import fsExtra from 'fs-extra';
 import IServerConfig from './IServerConfig';
+import settingsCache from './settingsCache';
 
 let updateAvailable: boolean = false;
 let updating: boolean = false;
@@ -31,6 +32,8 @@ export default async function boot(
     websocket: SocketIO.Server,
     serverConfig: IServerConfig
 ): Promise<void> {
+    autoUpdater.allowPrerelease = settingsCache.getSettings().allowPrerelease;
+
     autoUpdater.on('update-downloaded', async () => {
         updateAvailable = true;
 


### PR DESCRIPTION
Hey,

I added a switch to the general settings to enable prereleases. If this switch is toggled on future features (like Lumi Run now) are shown. The client then also updates from `vX.x.x-beta` releases from the beta branch.

