### PR TITLE
feat(boot): added file association

### DIFF
--- a/builder.config.js
+++ b/builder.config.js
@@ -28,7 +28,11 @@ module.exports = {
     afterSign: 'scripts/notarize.js',
     win: {
         icon: 'electron/assets/lumi.png',
-        target: ['appx', 'nsis']
+        target: ['appx', 'nsis'],
+        fileAssociations: {
+            ext: 'h5p',
+            name: 'H5P'
+        }
     },
     appx: {
         identityName: process.env.APPX_IDENTITY_NAME,
@@ -36,6 +40,9 @@ module.exports = {
         publisher: process.env.APPX_PUBLISHER,
         displayName: process.env.APPX_DISPLAY_NAME,
         publisherDisplayName: process.env.APPX_PUBLISHER_DISPLAY_NAME
+    },
+    nsis: {
+        deleteAppDataOnUninstall: true
     },
     linux: {
         category: 'Utility',

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "build:mac:dev": "CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:mac",
         "build:sentry": "RELEASE=true npm run build:client",
         "build:server": "npx tsc --project tsconfig.json",
-        "build:win": "npm run build && cp -r electron/assets/appx build && npx --no-install electron-builder --config builder.config.js --win --publish never && rm -rf build/appx",
+        "build:win": "npm run build && cp -r electron/assets/appx build && npx --no-install electron-builder --config builder.config.js --windows nsis --publish never && rm -rf build/appx",
         "ci": "npm run lint && npm run format:check && npm run build && npm run test",
         "clean": "rm -rf build/",
         "format": "npx prettier --write \"{server,client,test}/**/*.{ts,tsx}\"",

--- a/server/src/helpers/DelayedEmitter.ts
+++ b/server/src/helpers/DelayedEmitter.ts
@@ -1,0 +1,47 @@
+import SocketIO from 'socket.io';
+import log from 'electron-log';
+
+export default class DelayedEmitter {
+    constructor(private websocket?: SocketIO.Server) {
+        log.debug(`DelayedEmitter: Initialized"`);
+        if (this.websocket) {
+            this.websocket.on('connection', this.onConnection);
+        }
+    }
+
+    private eventQueue: {
+        data: any;
+        name: string;
+    }[] = [];
+    private isConnected: boolean = false;
+
+    public emit = (name: string, data: any): void => {
+        if (this.isConnected) {
+            log.debug(`DelayedEmitter: Immediately emitting event "${name}"`);
+            this.websocket.emit(name, data);
+        } else {
+            log.debug(`DelayedEmitter: Queueing event "${name}"`);
+            this.eventQueue.push({ name, data });
+        }
+    };
+    
+    public setWebsocket = (websocket: SocketIO.Server): void => {
+        log.debug(`DelayedEmitter: Set websocket`);
+        this.websocket = websocket;
+        this.websocket.on('connection', this.onConnection);
+    };
+
+    private emitQueue = (): void => {
+        log.debug('DelayedEmitter: Emitting queued events');
+        for (const event of this.eventQueue) {
+            this.websocket.emit(event.name, event.data);
+        }
+        this.eventQueue = [];
+    };
+
+    private onConnection = () => {
+        log.debug('DelayedEmitter: Websocket connected');
+        this.isConnected = true;
+        this.emitQueue();
+    };
+}

--- a/server/src/helpers/DelayedEmitter.ts
+++ b/server/src/helpers/DelayedEmitter.ts
@@ -1,40 +1,57 @@
 import SocketIO from 'socket.io';
 import log from 'electron-log';
 
+/**
+ * Wraps around SocketIO.Server and queues events until the websocket connection
+ * to the client is established. Events sent after the connection is established
+ * are sent directly without delay.
+ */
 export default class DelayedEmitter {
-    constructor(private websocket?: SocketIO.Server) {
+    constructor(private websocketServer?: SocketIO.Server) {
         log.debug(`DelayedEmitter: Initialized"`);
-        if (this.websocket) {
-            this.websocket.on('connection', this.onConnection);
+        if (this.websocketServer) {
+            this.websocketServer.on('connection', this.onConnection);
         }
     }
 
     private eventQueue: {
-        data: any;
+        /**
+         * The arguments of the event.
+         */
+        args: any[];
+        /**
+         * The name of the event.
+         */
         name: string;
     }[] = [];
     private isConnected: boolean = false;
 
-    public emit = (name: string, data: any): void => {
+    /**
+     * Queues the event or emits it directly, depending on whether the websocket
+     * is already connected.
+     * @param name the name of the event
+     * @param args the custom arguments to pass alongside the event name
+     */
+    public emit = (name: string, ...args: any[]): void => {
         if (this.isConnected) {
             log.debug(`DelayedEmitter: Immediately emitting event "${name}"`);
-            this.websocket.emit(name, data);
+            this.websocketServer.emit(name, ...args);
         } else {
             log.debug(`DelayedEmitter: Queueing event "${name}"`);
-            this.eventQueue.push({ name, data });
+            this.eventQueue.push({ name, args });
         }
     };
-    
+
     public setWebsocket = (websocket: SocketIO.Server): void => {
         log.debug(`DelayedEmitter: Set websocket`);
-        this.websocket = websocket;
-        this.websocket.on('connection', this.onConnection);
+        this.websocketServer = websocket;
+        this.websocketServer.on('connection', this.onConnection);
     };
 
     private emitQueue = (): void => {
         log.debug('DelayedEmitter: Emitting queued events');
         for (const event of this.eventQueue) {
-            this.websocket.emit(event.name, event.data);
+            this.websocketServer.emit(event.name, ...event.args);
         }
         this.eventQueue = [];
     };

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -16,7 +16,7 @@ import i18next from 'i18next';
 
 import settingsCache from './settingsCache';
 import electronState from './electronState';
-import DelayedEmitter from './helpers/delayedEmitter';
+import DelayedEmitter from './helpers/DelayedEmitter';
 
 const app = electron.app;
 let websocket: SocketIO.Server;

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -20,7 +20,13 @@ import DelayedEmitter from './helpers/delayedEmitter';
 
 const app = electron.app;
 let websocket: SocketIO.Server;
-let delayedWebsocketEmitter: DelayedEmitter = new DelayedEmitter();
+/**
+ * The DelayedEmitter queues websocket events until the websocket is connected.
+ * We need it as the browser window and the client must be initialized before
+ * we can send events, but the events are raised by the startup routine before
+ * the initialization is over.
+ */
+const delayedWebsocketEmitter: DelayedEmitter = new DelayedEmitter();
 let mainWindow: electron.BrowserWindow;
 let port: number;
 let currentPath: string = '/';
@@ -181,7 +187,7 @@ app.on('ready', async () => {
 
     websocket = websocketFactory(server);
     log.info('websocket created');
-    
+
     delayedWebsocketEmitter.setWebsocket(websocket);
 
     updater(app, websocket, serverConfig);


### PR DESCRIPTION
This PR allows opening .h5p files in the Windows Explorer by double clicking them. MacOS might also work now.

If you select multiple files, multiple instances of Lumi open at the moment.

There's still a bug if you open Lumi with a file association directly after installing it.