### PR TITLE
fix(boot): file associations always work

### DIFF
--- a/client/src/state/Settings/SettingsActions.ts
+++ b/client/src/state/Settings/SettingsActions.ts
@@ -71,7 +71,18 @@ export function updateSettings(settings: ISettingsState): any {
     };
 }
 
-export function changeSetting(payload: Partial<ISettingsState>): any {
+/**
+ *
+ * @param payload
+ * @param save If true, the setting change will also be persisted, if false the
+ * change will only be performed in the Redux state, but not persisted to the
+ * disk.
+ * @returns
+ */
+export function changeSetting(
+    payload: Partial<ISettingsState>,
+    save: boolean = false
+): any {
     return async (dispatch: any) => {
         try {
             dispatch({
@@ -79,7 +90,9 @@ export function changeSetting(payload: Partial<ISettingsState>): any {
                 type: SETTINGS_CHANGE
             });
 
-            dispatch(updateSettings(store.getState().settings));
+            if (save) {
+                dispatch(updateSettings(store.getState().settings));
+            }
         } catch (error) {
             Sentry.captureException(error);
         }

--- a/client/src/views/components/SetupDialog.tsx
+++ b/client/src/views/components/SetupDialog.tsx
@@ -147,10 +147,13 @@ export default function CustomizedDialogs() {
                                 edge="end"
                                 onChange={() =>
                                     dispatch(
-                                        actions.settings.changeSetting({
-                                            privacyPolicyConsent:
-                                                !settings.privacyPolicyConsent
-                                        })
+                                        actions.settings.changeSetting(
+                                            {
+                                                privacyPolicyConsent:
+                                                    !settings.privacyPolicyConsent
+                                            },
+                                            false
+                                        )
                                     )
                                 }
                                 checked={settings.privacyPolicyConsent}
@@ -175,9 +178,13 @@ export default function CustomizedDialogs() {
                                 edge="end"
                                 onChange={() =>
                                     dispatch(
-                                        actions.settings.changeSetting({
-                                            bugTracking: !settings.bugTracking
-                                        })
+                                        actions.settings.changeSetting(
+                                            {
+                                                bugTracking:
+                                                    !settings.bugTracking
+                                            },
+                                            false
+                                        )
                                     )
                                 }
                                 checked={settings.bugTracking}
@@ -202,10 +209,13 @@ export default function CustomizedDialogs() {
                                 edge="end"
                                 onChange={() =>
                                     dispatch(
-                                        actions.settings.changeSetting({
-                                            usageStatistics:
-                                                !settings.usageStatistics
-                                        })
+                                        actions.settings.changeSetting(
+                                            {
+                                                usageStatistics:
+                                                    !settings.usageStatistics
+                                            },
+                                            false
+                                        )
                                     )
                                 }
                                 checked={settings.usageStatistics}
@@ -231,10 +241,13 @@ export default function CustomizedDialogs() {
                                     edge="end"
                                     onChange={() =>
                                         dispatch(
-                                            actions.settings.changeSetting({
-                                                autoUpdates:
-                                                    !settings.autoUpdates
-                                            })
+                                            actions.settings.changeSetting(
+                                                {
+                                                    autoUpdates:
+                                                        !settings.autoUpdates
+                                                },
+                                                false
+                                            )
                                         )
                                     }
                                     checked={settings.autoUpdates}

--- a/server/src/helpers/DelayedEmitter.ts
+++ b/server/src/helpers/DelayedEmitter.ts
@@ -58,6 +58,17 @@ export default class DelayedEmitter {
         }
     };
 
+    /**
+     * Sets the connection state to false again and listens for a new connection.
+     */
+    public resetWebsocketConnection = () => {
+        log.debug(
+            `DelayedEmitter: Resetting websocket connected state and waiting for new connection event`
+        );
+        this.isConnected = false;
+        this.websocketServer.on('connection', this.onConnection);
+    };
+
     public setWebsocket = (websocket: SocketIO.Server): void => {
         log.debug(`DelayedEmitter: Set websocket`);
         this.websocketServer = websocket;

--- a/server/src/settingsCache.ts
+++ b/server/src/settingsCache.ts
@@ -19,12 +19,26 @@ class SettingsStorage {
     }
     public settings: ISettingsState;
 
+    private subscribers: (() => void)[] = [];
+
     getSettings(): ISettingsState {
         return this.settings;
     }
 
     setSettings(s: ISettingsState): void {
         this.settings = s;
+        this.subscribers.forEach((subscriber) => subscriber());
+    }
+
+    subscribe(handler: () => void): void {
+        this.subscribers.push(handler);
+    }
+
+    unsubscribe(handler: () => void): void {
+        const index = this.subscribers.indexOf(handler);
+        if (index >= 0) {
+            this.subscribers.splice(index, 1);
+        }
     }
 }
 


### PR DESCRIPTION
There were a few edge cases in which loading Lumi from a file association didn't work properly:

- if the user starts Lumi with from file association on first run, the loading of the file is delayed until the user has consented to data transmission
- if the user has closed all Lumi windows in macOS, but the app is still loaded, a new window is created if the user loads a h5p through a file association

I tested this on macOS and Windows. In Windows you still get multiple windows if you open further .h5p files from the File Explorer. Things still work, but we should change this behavior soon when we change the way temporary files are stored.