### PR TITLE
fix(language): add arabic to language selection

### DIFF
--- a/client/src/views/components/Settings/LanguageList.tsx
+++ b/client/src/views/components/Settings/LanguageList.tsx
@@ -53,6 +53,7 @@ export default function LanguageList() {
                 }}
             >
                 <MenuItem value={'af'}>Afrikaans</MenuItem>
+                <MenuItem value={'ar'}>العربية</MenuItem>
                 <MenuItem value={'bg'}>български език</MenuItem>
                 <MenuItem value={'bs'}>bosanski jezik</MenuItem>
                 <MenuItem value={'ca'}>català, valencià</MenuItem>


### PR DESCRIPTION
Hey,

the Arabic language was missing from the language selection menu, so I added it.