### PR TITLE
fix: set reportingIsEnabled flag

### DIFF
--- a/scorm-client/h5p-adaptor.js
+++ b/scorm-client/h5p-adaptor.js
@@ -62,6 +62,9 @@ var onCompleted = function (result) {
     }
 };
 
+// Some H5P content types require this to be set on the platform in order to allow submission of results
+H5PIntegration.reportingIsEnabled = true;
+
 H5P.externalDispatcher.on('xAPI', function (event) {
     if (event.data.statement.result) {
         onCompleted(event.data.statement.result);


### PR DESCRIPTION
When merged in, will set the `reportingIsEnabled` flag on `H5PIntegration`. This is required fore some content types such as H5P.InteractiveBook to allow score submission as they check the H5P integration's (here the scorm wrapper's) capability to handle reports.