### PR TITLE
Sanitize urlLibraries assignment for undefined CDN_BASE

### DIFF
--- a/src/express/controller/render-content.ts
+++ b/src/express/controller/render-content.ts
@@ -23,7 +23,7 @@ router.get(
         req.lng
       );
 
-      h5pContent.integration.urlLibraries = `${process.env.CDN_BASE}/h5p/libraries`;
+      h5pContent.integration.urlLibraries = (process.env.CDN_BASE ?? '') + '/h5p/libraries';
 
       // hotfix for h5p-tooltip.js
       // TODO: Remove once https://github.com/Lumieducation/H5P-Nodejs-library/issues/3374 is fixed


### PR DESCRIPTION
When merged in, will sanitize the `urlLibraries` property of the `H5PIntegration` object.

Currently, `process.env.CDN_BASE` does not seem to be defined (at least on my Linux instance), thus yielding `undefined/h5p/libraries` for `H5PIntegration.urlLibraries`. It seems that `h5p/libraries` is the correct base path for Lumi, hence my suggested sanitization.

Without it, some H5P content types that call `H5P.getLibraryPath` (https://github.com/h5p/h5p-php-library/blob/1afd89a8bd1df4843dd946a82aaff35d62fdc507/js/h5p.js#L2077-L2092) will fail to retrieve the correct path.