### PR TITLE
fix(config): fix "save as" and file extension filter

### DIFF
--- a/src/menu/file/file_save_as.ts
+++ b/src/menu/file/file_save_as.ts
@@ -11,13 +11,14 @@ export default function file_save_as(ctx: Context): MenuItem {
     enabled: ctx.menu === 'content',
     accelerator: 'CmdOrCtrl+Shift+S',
     click: async () => {
+      const active_window = await window_get_active();
+      const content_id = await window_get_content_id(active_window);
+
       const { file_path, canceled } = await show_dialog_save_as();
 
       if (canceled) {
         return;
       }
-      const active_window = await window_get_active();
-      const content_id = await window_get_content_id(active_window);
       await window_backdrop_show(ctx, content_id);
       ctx.ws.emit(content_id, { type: 'save_as', payload: { file_path } });
     }

--- a/src/ops/dialog_save_as.ts
+++ b/src/ops/dialog_save_as.ts
@@ -6,7 +6,7 @@ export default async function show_dialog_save_as(): Promise<{
 }> {
   const result = await dialog.showSaveDialog({
     title: 'Save As',
-    filters: [{ name: '.h5p', extensions: ['.h5p'] }],
+    filters: [{ name: '.h5p', extensions: ['h5p'] }],
     properties: ['showOverwriteConfirmation']
   });
 


### PR DESCRIPTION
Root cause:
- There's a split second after confirming save location where Electron couldn't find a focused window, this causes an Exception and the file isn't saved.

Changes:
- identify focused window before showing save dialogue.

Verified by user @nettkursxyz in [this issue](https://github.com/Lumieducation/Lumi/issues/2717#issuecomment-3718384275).

According to [contributing guidelines](https://github.com/Lumieducation/Lumi/blob/21383652c9af025928979419e1a0f69c2012e44e/.github/CONTRIBUTING.md), the reviewer should be:

cc @JPSchellenberg 