### PR TITLE
chore: Update H5P content type hub endpoints

### DIFF
--- a/config/default_settings.ts
+++ b/config/default_settings.ts
@@ -17,8 +17,8 @@ const default_settings = {
   https_proxy: '',
   http_proxy: '',
 
-  hub_content_types_endpoint: 'https://api.h5p.org/v1/content-types/',
-  hub_registration_endpoint: 'https://api.h5p.org/v1/sites'
+  hub_content_types_endpoint: 'https://hub-api.h5p.org/v1/content-types/',
+  hub_registration_endpoint: 'https://hub-api.h5p.org/v1/sites'
 };
 
 export default default_settings;

--- a/config/h5p-config.ts
+++ b/config/h5p-config.ts
@@ -88,9 +88,9 @@ export default class H5PConfig implements IH5PConfig {
   public h5pVersion: string = '1.27';
 
   public hubContentTypesEndpoint: string =
-    'https://api.h5p.org/v1/content-types/';
+    'https://hub-api.h5p.org/v1/content-types/';
 
-  public hubRegistrationEndpoint: string = 'https://api.h5p.org/v1/sites';
+  public hubRegistrationEndpoint: string = 'https://hub-api.h5p.org/v1/sites';
 
   public installLibraryLockMaxOccupationTime: number = 30000;
 


### PR DESCRIPTION
When merged in, will update references to the H5P content type Hub server.

H5P Group updated their endpoints: https://github.com/h5p/h5p-php-library/commit/69c25bf67671e25ceafc26358b7dfc9c8be6aeed

Please note that I did not update the reference in `h5p-hub-client.js` as this file is part of H5P core which should/will be updated once the newer H5P core version is used.