### PR TITLE
Prevent .h5p files from being corrupted while saving

### DIFF
--- a/src/events/websocket/content_save_locks.ts
+++ b/src/events/websocket/content_save_locks.ts
@@ -1,0 +1,3 @@
+const activeContentSaves = new Set<string>();
+
+export default activeContentSaves;

--- a/src/events/websocket/save.ts
+++ b/src/events/websocket/save.ts
@@ -1,6 +1,7 @@
 import * as SocketIO from 'socket.io';
 
 import { Context } from '../../boot';
+import activeContentSaves from './content_save_locks';
 import content_config_read from '../../ops/content_config_read';
 import content_save_to_file from '../../ops/content_save_to_file';
 import window_backdrop_hide from '../../ops/window_backdrop_hide';
@@ -14,15 +15,28 @@ export default function setup_save(
     context.log.info('events:websocket:save', payload);
 
     const { contentId } = payload;
-    const path = await content_config_read(context, contentId, 'path');
+    if (activeContentSaves.has(contentId)) {
+      context.log.warn('events:websocket:save already in progress', {
+        contentId
+      });
+      return;
+    }
 
-    await content_save_to_file(context, contentId, path);
-    await window_backdrop_hide(context, contentId);
-    await window_snackbar_show(
-      context,
-      contentId,
-      context.translate(`Content saved to {{file_path}}`, { file_path: path }),
-      'success'
-    );
+    activeContentSaves.add(contentId);
+    try {
+      const path = await content_config_read(context, contentId, 'path');
+      await content_save_to_file(context, contentId, path);
+      await window_backdrop_hide(context, contentId);
+      await window_snackbar_show(
+        context,
+        contentId,
+        context.translate(`Content saved to {{file_path}}`, {
+          file_path: path
+        }),
+        'success'
+      );
+    } finally {
+      activeContentSaves.delete(contentId);
+    }
   });
 }

--- a/src/events/websocket/save.ts
+++ b/src/events/websocket/save.ts
@@ -19,6 +19,13 @@ export default function setup_save(
       context.log.warn('events:websocket:save already in progress', {
         contentId
       });
+      await window_backdrop_hide(context, contentId);
+      await window_snackbar_show(
+        context,
+        contentId,
+        context.translate('Save already in progress'),
+        'info'
+      );
       return;
     }
 

--- a/src/events/websocket/save_as.ts
+++ b/src/events/websocket/save_as.ts
@@ -14,8 +14,8 @@ export default function setup_save(
     context.log.info('events:websocket:save_as', payload);
     const { contentId, file_path } = payload;
 
-    await content_config_write(context, contentId, 'path', file_path);
     await content_save_to_file(context, contentId, file_path);
+    await content_config_write(context, contentId, 'path', file_path);
     await window_backdrop_hide(context, contentId);
     await window_snackbar_show(
       context,

--- a/src/events/websocket/save_as.ts
+++ b/src/events/websocket/save_as.ts
@@ -1,6 +1,7 @@
 import * as SocketIO from 'socket.io';
 
 import { Context } from '../../boot';
+import activeContentSaves from './content_save_locks';
 import content_config_write from '../../ops/content_config_write';
 import content_save_to_file from '../../ops/content_save_to_file';
 import window_backdrop_hide from '../../ops/window_backdrop_hide';
@@ -14,14 +15,26 @@ export default function setup_save(
     context.log.info('events:websocket:save_as', payload);
     const { contentId, file_path } = payload;
 
-    await content_save_to_file(context, contentId, file_path);
-    await content_config_write(context, contentId, 'path', file_path);
-    await window_backdrop_hide(context, contentId);
-    await window_snackbar_show(
-      context,
-      contentId,
-      context.translate(`Content saved to {{file_path}}`, { file_path }),
-      'success'
-    );
+    if (activeContentSaves.has(contentId)) {
+      context.log.warn('events:websocket:save_as already in progress', {
+        contentId
+      });
+      return;
+    }
+
+    activeContentSaves.add(contentId);
+    try {
+      await content_save_to_file(context, contentId, file_path);
+      await content_config_write(context, contentId, 'path', file_path);
+      await window_backdrop_hide(context, contentId);
+      await window_snackbar_show(
+        context,
+        contentId,
+        context.translate(`Content saved to {{file_path}}`, { file_path }),
+        'success'
+      );
+    } finally {
+      activeContentSaves.delete(contentId);
+    }
   });
 }

--- a/src/ops/content_save_to_file.ts
+++ b/src/ops/content_save_to_file.ts
@@ -1,4 +1,7 @@
 import fs from 'fs';
+import path from 'path';
+import fsPromises from 'fs/promises';
+import { finished } from 'stream/promises';
 import * as H5P from '@lumieducation/h5p-server';
 
 import { Context } from '../boot';
@@ -7,30 +10,37 @@ import User from '../models/User';
 export default async function content_save_to_file(
   ctx: Context,
   content_id: string,
-  path: string
+  filePath: string
 ): Promise<void> {
   ctx.log.debug(`ops:content_save_to_file`, {
     content_id,
-    path
+    path: filePath
   });
 
-  const stream = fs.createWriteStream(path);
+  const tempPath = path.join(path.dirname(filePath),`.${path.basename(filePath)}.${Date.now()}.tmp`);
+  const stream = fs.createWriteStream(tempPath);
+  const streamFinished = finished(stream);
   const packageExporter = new H5P.PackageExporter(
     ctx.h5pEditor.libraryManager,
     ctx.h5pEditor.contentStorage,
     ctx.h5pEditor.config
   );
 
-  await packageExporter.createPackage(content_id, stream, new User());
+  try {
+    await packageExporter.createPackage(content_id, stream, new User());
 
-  // We also need to wait for the stream to finish before returning, so
-  // that the user is notified correctly about fact that saving is still
-  // going on.
-  await new Promise<void>((y, n) => {
-    stream.on('finish', () => {
-      y();
-    });
-  }).finally(() => {
-    stream.close();
-  });
+    // We wait for the writable stream and surface stream errors before replacing
+    // the existing file.
+    await streamFinished;
+    await fsPromises.rename(tempPath, filePath);
+  } catch (error) {
+    stream.destroy();
+    try {
+      await streamFinished;
+    } catch {
+      // Silently ignore errors from the stream, as we're already handling the main error
+    }
+    await fsPromises.rm(tempPath, { force: true });
+    throw error;
+  }
 }


### PR DESCRIPTION
This MR tries to solve #2739 & #2740 by improving the saving logic

## Changes:

1. Instead of directly streaming data to the existing file, we now write to a temp file and only when that is completely done and successful we overwrite the existing file.
2. Introduced a saving lock to prevent saving when another save is in progress.

## What is left:

One issue remains, and that is that somehow we register multiple listeners that that call the save websocket, with the save locking introduced in this MR that is not a big issue, but I would like to know where this happens, any help in that area would be much appreciated.

